### PR TITLE
Adds deploy action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: build
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: 0 0 * * 0     # weekly
+  pull_request:
+    branches:
+    - main
+  push:
+    branches:
+    - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, '3.10']
+      # this makes sure we run all tests, even if some fail
+      fail-fast: false
+    name: Run tests
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Python 3
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: setup.py
+    - name: Install dependencies
+      run: |
+        # using the --upgrade and --upgrade-strategy eager flags ensures that
+        # pip will always install the latest allowed version of all
+        # dependencies, to make sure the cache doesn't go stale
+        pip install --upgrade --upgrade-strategy eager .
+        pip install pytest
+    - name: Run tests
+      run: |
+        pytest tests/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: deploy
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build --outdir dist/ --sdist
+      - name: Publish package to test pypi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,5 +22,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,4 +22,5 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy
-scipy
-matplotlib
-munkres

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ setup(
     license=LICENSE,
     install_requires=install_requires,
     python_requires='>=3',
+    project_urls={
+        'Documentation': 'https://tensortools-docs.readthedocs.io/',
+    }
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
     name=NAME,
     version=VERSION,
     description=DESCRIPTION,
+    long_description=open('README.md', 'r').read(),
+    long_description_content_type='text/markdown',
     url=URL,
     author=AUTHOR,
     author_email=EMAIL,

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     python_requires='>=3',
     project_urls={
         'Documentation': 'https://tensortools-docs.readthedocs.io/',
-    }
+    },
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,9 @@ install_requires = [
     'scipy',
     'tqdm',
     'munkres',
-    'numba'
+    'numba',
+    'matplotlib',
 ]
-
-tests_require = ['pytest', 'numpy', 'scipy', 'numba']
-setup_requires = ['pytest-runner']
 
 setup(
     name=NAME,
@@ -31,8 +29,6 @@ setup(
     author_email=EMAIL,
     license=LICENSE,
     install_requires=install_requires,
-    tests_require=tests_require,
-    setup_requires=setup_requires,
     python_requires='>=3',
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This PR adds `deploy.yml`, which will deploy the package to pypi when you publish a github release. It requires two things:
- you add a `PYPI_API_TOKEN` to your repo's secrets (see [here](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) for how to do that, [this guide](https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries) may also be helpful). You only have to do this once.
- **before** you publish a release (so, each time), you need to update the version number. For you, this is the `VERSION` variable in your `setup.py`. pypi only sees that version number, not the github release name (I haven't found a way to tie them together yet)

Finally, I also added `long_description` to your `setup.py`. This was necessary for me to deploy my package correctly, though there might be a work-around. It just makes your readme show up on the pypi page, which I figure is worth doing.

You probably should test this first, in which case, see [the guide linked earlier](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) about how to publish to test.pypi.org instead.

Let me know if you have any issues!